### PR TITLE
rgb cache + styled func perf improvements

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,8 +1,9 @@
 package termenv
 
 import (
-	"container/list"
 	"sync"
+	"sync/atomic"
+	"time"
 )
 
 func init() {
@@ -23,97 +24,101 @@ func GetRGBCache() *RGBCache {
 	return globalRGBCache
 }
 
-// Hasher is an interface that requires a Hash method. The Hash method is
-// expected to return a string representation of the hash of the object.
-type Hasher interface {
-	Hash() string
-}
-
-// SequenceEntry is a struct that holds a key-value pair. It is used as an element
-// in the evictionList of the Cache.
-type SequenceEntry struct {
-	key   [32]byte
-	value string
-}
-
-// RGBCache is a struct that represents a cache with a set capacity. It
-// uses an LRU (Least Recently Used) eviction policy. It is safe for
-// concurrent use.
 type RGBCache struct {
-	capacity     int
-	mutex        sync.Mutex
-	cache        map[[32]byte]*list.Element // The cache holding the results
-	evictionList *list.List                 // A list to keep track of the order for LRU
+	data     sync.Map
+	capacity int
+	size     int64 // atomic counter
 }
 
-// NewRGBCache is a function that creates a new Cache with a given
-// capacity. It returns a pointer to the created Cache.
+type entry struct {
+	value    string
+	lastUsed int64 // nanosecond timestamp for better precision
+}
+
 func NewRGBCache(capacity int) *RGBCache {
 	return &RGBCache{
-		capacity:     capacity,
-		cache:        make(map[[32]byte]*list.Element),
-		evictionList: list.New(),
+		capacity: capacity,
 	}
 }
 
-// Capacity is a method that returns the capacity of the Cache.
-func (m *RGBCache) Capacity() int {
-	return m.capacity
-}
-
-// Size is a method that returns the current size of the Cache. It is
-// the number of items currently stored in the cache.
-func (m *RGBCache) Size() int {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-	return m.evictionList.Len()
-}
-
-// Get is a method that returns the value associated with the given
-// hashable item in the Cache. If there is no corresponding value, the
-// method returns nil.
-func (m *RGBCache) Get(h RGBColor) (string, bool) {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-
-	hashedKey := h.Hash()
-	if element, found := m.cache[hashedKey]; found {
-		m.evictionList.MoveToFront(element)
-		return element.Value.(*SequenceEntry).value, true
+func (c *RGBCache) Get(key RGBColor) (string, bool) {
+	val, ok := c.data.Load(key)
+	if !ok {
+		return "", false
 	}
-	var result string
-	return result, false
+
+	e := val.(*entry)
+	// Update access time
+	atomic.StoreInt64(&e.lastUsed, time.Now().UnixNano())
+
+	return e.value, true
 }
 
-// Set is a method that sets the value for the given hashable item in the
-// Cache. If the cache is at capacity, it evicts the least recently
-// used item before adding the new item.
-func (m *RGBCache) Set(h RGBColor, value string) {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
+func (c *RGBCache) Put(key RGBColor, value string) {
+	now := time.Now().UnixNano()
 
-	hashedKey := h.Hash()
-	if element, found := m.cache[hashedKey]; found {
-		m.evictionList.MoveToFront(element)
-		element.Value.(*SequenceEntry).value = value
+	// Check if key already exists
+	if val, ok := c.data.Load(key); ok {
+		// Update existing entry
+		e := val.(*entry)
+		e.value = value
+		atomic.StoreInt64(&e.lastUsed, now)
 		return
 	}
 
-	// Check if the cache is at capacity
-	if m.evictionList.Len() >= m.capacity {
-		// Evict the least recently used item from the cache
-		toEvict := m.evictionList.Back()
-		if toEvict != nil {
-			evictedEntry := m.evictionList.Remove(toEvict).(*SequenceEntry)
-			delete(m.cache, evictedEntry.key)
-		}
+	// New entry
+	newEntry := &entry{
+		value:    value,
+		lastUsed: now,
 	}
 
-	// Add the value to the cache and the evictionList
-	newEntry := &SequenceEntry{
-		key:   hashedKey,
-		value: value,
+	c.data.Store(key, newEntry)
+	newSize := atomic.AddInt64(&c.size, 1)
+
+	// Check if we need to evict
+	if int(newSize) > c.capacity {
+		c.evictLRU()
 	}
-	element := m.evictionList.PushFront(newEntry)
-	m.cache[hashedKey] = element
+}
+
+func (c *RGBCache) Delete(key RGBColor) bool {
+	_, existed := c.data.LoadAndDelete(key)
+	if existed {
+		atomic.AddInt64(&c.size, -1)
+	}
+	return existed
+}
+
+func (c *RGBCache) Len() int {
+	return int(atomic.LoadInt64(&c.size))
+}
+
+func (c *RGBCache) Clear() {
+	c.data.Range(func(key, value interface{}) bool {
+		c.data.Delete(key)
+		return true
+	})
+	atomic.StoreInt64(&c.size, 0)
+}
+
+// O(n) eviction - find and remove the least recently used entry
+func (c *RGBCache) evictLRU() {
+	var oldestKey interface{}
+	var oldestTime int64 = time.Now().UnixNano()
+
+	c.data.Range(func(key, value interface{}) bool {
+		e := value.(*entry)
+		lastUsed := atomic.LoadInt64(&e.lastUsed)
+
+		if lastUsed < oldestTime {
+			oldestTime = lastUsed
+			oldestKey = key
+		}
+		return true
+	})
+
+	if oldestKey != nil {
+		c.data.Delete(oldestKey)
+		atomic.AddInt64(&c.size, -1)
+	}
 }

--- a/cache.go
+++ b/cache.go
@@ -18,7 +18,7 @@ var (
 // It initializes the cache with default capacity on first call.
 func GetRGBCache() *RGBCache {
 	once.Do(func() {
-		globalRGBCache = NewRGBCache(10)
+		globalRGBCache = NewRGBCache(20)
 	})
 	return globalRGBCache
 }

--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,119 @@
+package termenv
+
+import (
+	"container/list"
+	"sync"
+)
+
+func init() {
+	GetRGBCache()
+}
+
+var (
+	globalRGBCache *RGBCache
+	once           sync.Once
+)
+
+// GetRGBCache returns the global RGB cache instance.
+// It initializes the cache with default capacity on first call.
+func GetRGBCache() *RGBCache {
+	once.Do(func() {
+		globalRGBCache = NewRGBCache(10)
+	})
+	return globalRGBCache
+}
+
+// Hasher is an interface that requires a Hash method. The Hash method is
+// expected to return a string representation of the hash of the object.
+type Hasher interface {
+	Hash() string
+}
+
+// SequenceEntry is a struct that holds a key-value pair. It is used as an element
+// in the evictionList of the Cache.
+type SequenceEntry struct {
+	key   [32]byte
+	value string
+}
+
+// RGBCache is a struct that represents a cache with a set capacity. It
+// uses an LRU (Least Recently Used) eviction policy. It is safe for
+// concurrent use.
+type RGBCache struct {
+	capacity     int
+	mutex        sync.Mutex
+	cache        map[[32]byte]*list.Element // The cache holding the results
+	evictionList *list.List                 // A list to keep track of the order for LRU
+}
+
+// NewRGBCache is a function that creates a new Cache with a given
+// capacity. It returns a pointer to the created Cache.
+func NewRGBCache(capacity int) *RGBCache {
+	return &RGBCache{
+		capacity:     capacity,
+		cache:        make(map[[32]byte]*list.Element),
+		evictionList: list.New(),
+	}
+}
+
+// Capacity is a method that returns the capacity of the Cache.
+func (m *RGBCache) Capacity() int {
+	return m.capacity
+}
+
+// Size is a method that returns the current size of the Cache. It is
+// the number of items currently stored in the cache.
+func (m *RGBCache) Size() int {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	return m.evictionList.Len()
+}
+
+// Get is a method that returns the value associated with the given
+// hashable item in the Cache. If there is no corresponding value, the
+// method returns nil.
+func (m *RGBCache) Get(h RGBColor) (string, bool) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	hashedKey := h.Hash()
+	if element, found := m.cache[hashedKey]; found {
+		m.evictionList.MoveToFront(element)
+		return element.Value.(*SequenceEntry).value, true
+	}
+	var result string
+	return result, false
+}
+
+// Set is a method that sets the value for the given hashable item in the
+// Cache. If the cache is at capacity, it evicts the least recently
+// used item before adding the new item.
+func (m *RGBCache) Set(h RGBColor, value string) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	hashedKey := h.Hash()
+	if element, found := m.cache[hashedKey]; found {
+		m.evictionList.MoveToFront(element)
+		element.Value.(*SequenceEntry).value = value
+		return
+	}
+
+	// Check if the cache is at capacity
+	if m.evictionList.Len() >= m.capacity {
+		// Evict the least recently used item from the cache
+		toEvict := m.evictionList.Back()
+		if toEvict != nil {
+			evictedEntry := m.evictionList.Remove(toEvict).(*SequenceEntry)
+			delete(m.cache, evictedEntry.key)
+		}
+	}
+
+	// Add the value to the cache and the evictionList
+	newEntry := &SequenceEntry{
+		key:   hashedKey,
+		value: value,
+	}
+	element := m.evictionList.PushFront(newEntry)
+	m.cache[hashedKey] = element
+}

--- a/cache.go
+++ b/cache.go
@@ -36,7 +36,13 @@ func GetSRGBCache() *RGBCache {
 	return sRGBCache
 }
 
-// RGBCache caches computed data given an RGBColor
+// RGBCache caches computed data given an RGBColor.
+// I added this because my TUI application renders markdown text with glamour (which calls funcs in this package)
+// many times per second over and over again. Since this is the main functionality of my TUI, I profiled this feature
+// and there were 3 funcs in termenv that were using much of the CPU time. Once I realized that my TUI would only ever
+// need a fixed number of terminal colors/styles (computed by this package every time glamour renders markdown), I figured
+// I'd create a cache for these. These caches (and one other perf tweak) led to almost a 2x reduction in CPU time for
+// the code-path I was targeting, and a 5x speedup in the direct callee of these termenv functions I modified.
 type RGBCache struct {
 	data sync.Map
 
@@ -46,7 +52,7 @@ type RGBCache struct {
 }
 
 type entry struct {
-	value      interface{}
+	value      interface{} // go 1.18 generics would be nice to have here!
 	lastAccess int64
 }
 

--- a/color.go
+++ b/color.go
@@ -1,7 +1,6 @@
 package termenv
 
 import (
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"math"
@@ -49,10 +48,6 @@ func (c ANSI256Color) String() string {
 
 // RGBColor is a hex-encoded color, e.g. "#abcdef".
 type RGBColor string
-
-func (c *RGBColor) Hash() [32]byte {
-	return sha256.Sum256([]byte(*c))
-}
 
 // ConvertToRGB converts a Color to a colorful.Color.
 func ConvertToRGB(c Color) colorful.Color {

--- a/color.go
+++ b/color.go
@@ -1,6 +1,7 @@
 package termenv
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"math"
@@ -48,6 +49,10 @@ func (c ANSI256Color) String() string {
 
 // RGBColor is a hex-encoded color, e.g. "#abcdef".
 type RGBColor string
+
+func (c *RGBColor) Hash() [32]byte {
+	return sha256.Sum256([]byte(*c))
+}
 
 // ConvertToRGB converts a Color to a colorful.Color.
 func ConvertToRGB(c Color) colorful.Color {

--- a/profile.go
+++ b/profile.go
@@ -63,29 +63,28 @@ func (p Profile) Convert(c Color) Color {
 
 	case RGBColor:
 		var (
-			rgbString = string(v)
-			h         colorful.Color
-			err       error
+			h       colorful.Color
+			present bool
+			sRGB    interface{}
+			err     error
 		)
-		cache := GetRGBHexCache()
-		// cacheKey := strconv.Itoa(int(p)) + rgbString
-		if hex, ok := cache.Get(rgbString); ok {
-			if hexColor, ok := hex.(colorful.Color); ok {
-				h = hexColor
+		cache := GetSRGBCache()
+		if sRGB, present = cache.Get(v); present {
+			if sRGBColor, ok := sRGB.(colorful.Color); ok {
+				h = sRGBColor
 			} else {
-				panic("hexcache value type assertion failed")
+				panic("srgbCache value type assertion failed")
 			}
 		} else {
-			h, err = colorful.Hex(rgbString)
+			present = false
+			h, err = colorful.Hex(string(v))
 			if err != nil {
 				return nil
 			}
 		}
-		cache.Put(rgbString, h)
-		// h, err := colorful.Hex(string(v))
-		// if err != nil {
-		// 	return nil
-		// }
+		if !present {
+			cache.Put(v, h)
+		}
 
 		if p != TrueColor {
 			ac := hexToANSI256Color(h)

--- a/profile.go
+++ b/profile.go
@@ -62,10 +62,31 @@ func (p Profile) Convert(c Color) Color {
 		return v
 
 	case RGBColor:
-		h, err := colorful.Hex(string(v))
-		if err != nil {
-			return nil
+		var (
+			rgbString = string(v)
+			h         colorful.Color
+			err       error
+		)
+		cache := GetRGBHexCache()
+		// cacheKey := strconv.Itoa(int(p)) + rgbString
+		if hex, ok := cache.Get(rgbString); ok {
+			if hexColor, ok := hex.(colorful.Color); ok {
+				h = hexColor
+			} else {
+				panic("hexcache value type assertion failed")
+			}
+		} else {
+			h, err = colorful.Hex(rgbString)
+			if err != nil {
+				return nil
+			}
 		}
+		cache.Put(rgbString, h)
+		// h, err := colorful.Hex(string(v))
+		// if err != nil {
+		// 	return nil
+		// }
+
 		if p != TrueColor {
 			ac := hexToANSI256Color(h)
 			if p == ANSI {

--- a/style.go
+++ b/style.go
@@ -64,15 +64,20 @@ func (t Style) Foreground(c Color) Style {
 
 	var seq string
 	if rgb, ok := c.(RGBColor); ok {
-		cache := GetRGBCache()
-		if s, ok := cache.Get(rgb); ok {
-			t.styles = append(t.styles, s)
-			seq = s
+		cache := GetRGBSequenceCache()
+		cacheKey := string(rgb)
+		if s, ok := cache.Get(cacheKey); ok {
+			if sequence, ok := s.(string); ok {
+				t.styles = append(t.styles, sequence)
+				seq = sequence
+			} else {
+				panic("rgbcache value type assertion failed")
+			}
 		} else {
 			seq = rgb.Sequence(false)
 			t.styles = append(t.styles, seq)
 		}
-		cache.Put(rgb, seq)
+		cache.Put(cacheKey, seq)
 	} else {
 		t.styles = append(t.styles, c.Sequence(false))
 	}

--- a/style.go
+++ b/style.go
@@ -52,16 +52,15 @@ func (t Style) Styled(s string) string {
 		return s
 	}
 
-	var sb strings.Builder
-	sb.Grow(len(CSI)*2 + len(s) + len(ResetSeq) + len(seq))
-	sb.WriteString(CSI)
-	sb.WriteString(seq)
-	sb.WriteString("m")
-	sb.WriteString(s)
-	sb.WriteString(CSI)
-	sb.WriteString(ResetSeq)
-	sb.WriteString("m")
-	return sb.String()
+	buf := make([]byte, 0, len(CSI)*2+len(seq)+len(s)+len(ResetSeq)+2)
+	buf = append(buf, CSI...)
+	buf = append(buf, seq...)
+	buf = append(buf, "m"...)
+	buf = append(buf, s...)
+	buf = append(buf, CSI...)
+	buf = append(buf, ResetSeq...)
+	buf = append(buf, "m"...)
+	return string(buf)
 }
 
 // Foreground sets a foreground color.

--- a/style.go
+++ b/style.go
@@ -24,16 +24,14 @@ const (
 type Style struct {
 	profile Profile
 	string
-	styles   []string
-	rgbCache *RGBCache
+	styles []string
 }
 
 // String returns a new Style.
 func String(s ...string) Style {
 	return Style{
-		profile:  ANSI,
-		string:   strings.Join(s, " "),
-		rgbCache: NewRGBCache(5),
+		profile: ANSI,
+		string:  strings.Join(s, " "),
 	}
 }
 
@@ -74,7 +72,7 @@ func (t Style) Foreground(c Color) Style {
 			seq = rgb.Sequence(false)
 			t.styles = append(t.styles, seq)
 		}
-		cache.Set(rgb, seq)
+		cache.Put(rgb, seq)
 	} else {
 		t.styles = append(t.styles, c.Sequence(false))
 	}

--- a/style.go
+++ b/style.go
@@ -1,7 +1,6 @@
 package termenv
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/rivo/uniseg"
@@ -53,7 +52,16 @@ func (t Style) Styled(s string) string {
 		return s
 	}
 
-	return fmt.Sprintf("%s%sm%s%sm", CSI, seq, s, CSI+ResetSeq)
+	var sb strings.Builder
+	sb.Grow(len(CSI)*2 + len(s) + len(ResetSeq) + len(seq))
+	sb.WriteString(CSI)
+	sb.WriteString(seq)
+	sb.WriteString("m")
+	sb.WriteString(s)
+	sb.WriteString(CSI)
+	sb.WriteString(ResetSeq)
+	sb.WriteString("m")
+	return sb.String()
 }
 
 // Foreground sets a foreground color.


### PR DESCRIPTION
My side-project [ducky](https://github.com/gregriff/ducky) uses [glamour](https://github.com/charmbracelet/glamour) to render markdown many times per second, over and over again. This is the hottest code path. 

After profiling this, I saw that 3 functions in termenv were taking up a significant portion of the flamegraph. This release optimizes two of them with hashtables and the other with an improved string-building operation. 

The hash tables were used because I knew that my app would be using a small fixed-number of terminal colors 99% of the time. The hash tables just cache these in two places. The string building uses a byte slice instead of `fmt.Sprintf` because the size of the string is known. 

These optimizations roughly cut the CPU time of glamour's `ansi.renderText` by two-thirds. Maybe someone else who repeatedly uses glamour in this way [mods?](https://github.com/charmbracelet/mods) could find this useful. 